### PR TITLE
feat: add syntax highlighting for `.d2` and markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.wasm
+grammars/
+
 ### JetBrains ###
 # User-specific stuff
 .idea

--- a/examples/basic.d2
+++ b/examples/basic.d2
@@ -1,0 +1,4 @@
+hello
+w: world
+
+hello -> w: there

--- a/examples/chess.d2
+++ b/examples/chess.d2
@@ -1,0 +1,21 @@
+# Actors
+hans: Hans Niemann
+
+defendants: {
+  mc: Magnus Carlsen
+  playmagnus: Play Magnus Group
+  chesscom: Chess.com
+  naka: Hikaru Nakamura
+
+  mc -> playmagnus: Owns majority
+  playmagnus <-> chesscom: Merger talks
+  chesscom -> naka: Sponsoring
+}
+
+# Accusations
+hans -> defendants: 'sueing for $100M'
+
+# Offense
+defendants.naka -> hans: Accused of cheating on his stream
+defendants.mc -> hans: Lost then withdrew with accusations
+defendants.chesscom -> hans: 72 page report of cheating

--- a/examples/class.d2
+++ b/examples/class.d2
@@ -1,0 +1,30 @@
+Duck: {
+	shape: class
+	beakColor: String
+	swim(): void
+	quack(): void
+}
+
+Fish: {
+	shape: class
+	-sizeInFeet: int
+	-canEat(): boolean
+}
+
+Zebra: {
+	shape: class
+	is_wild: bool
+	run(): void
+}
+
+Animal: {
+	shape: class
+	age: int
+	gender: String
+	isMammal(): bool
+	mate(): void
+}
+
+Duck -> Animal
+Fish -> Animal
+Zebra -> Animal

--- a/examples/code.d2
+++ b/examples/code.d2
@@ -1,0 +1,17 @@
+hash: |go
+  // RegisterHash registers a function that returns a new instance of the given
+  // hash function. This is intended to be called from the init function in
+  // packages that implement hash functions.
+  func RegisterHash(h Hash, f func() hash.Hash) {
+  	if h >= maxHash {
+  		panic("crypto: RegisterHash of unknown hash function")
+  	}
+  	hashes[h] = f
+  }
+|
+hello world: |python
+  def hello():
+    print "world"
+|
+x -> hash -> y
+x -> hello world

--- a/examples/containers.d2
+++ b/examples/containers.d2
@@ -1,0 +1,8 @@
+parent: {
+	childB: {
+		grandchild
+	}
+	childA -> childB.grandchild
+}
+
+foo -> parent.childA

--- a/examples/icons.d2
+++ b/examples/icons.d2
@@ -1,0 +1,41 @@
+aws: {
+  db: "" {
+    icon: https://icons.terrastruct.com/azure/Databases%20Service%20Color/Azure%20Database%20for%20PostgreSQL%20servers.svg
+    shape: image
+  }
+
+  cache: "" {
+    icon: https://icons.terrastruct.com/azure/_Companies/Azure%20Cache%20Redis%20Product%20icon.svg
+    shape: image
+  }
+
+  ec2: "" {
+    icon: https://icons.terrastruct.com/aws/_Group%20Icons/EC2-instance-container_light-bg.svg
+    shape: image
+  }
+
+  ec2 <-> db: get persisted data
+  ec2 <-> cache: get temporal data
+}
+
+gcloud: {
+  db: "" {
+    icon: https://icons.terrastruct.com/azure/Databases%20Service%20Color/Azure%20Database%20for%20PostgreSQL%20servers.svg
+    shape: image
+  }
+}
+
+aws.db -> gcloud.db: backup
+
+dev: "" {
+  icon: https://icons.terrastruct.com/essentials/005-programmer.svg
+  shape: image
+}
+
+github: "" {
+  icon: https://icons.terrastruct.com/dev/github.svg
+  shape: image
+}
+
+dev -> aws.ec2: ssh
+dev -> github: version control

--- a/examples/latex.d2
+++ b/examples/latex.d2
@@ -1,0 +1,6 @@
+plankton -> formula: will steal
+formula: {
+  equation: |latex
+    \\lim_{h \\rightarrow 0 } \\frac{f(x+h)-f(x)}{h}
+  |
+}

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -1,0 +1,10 @@
+This is a markdown example of the D2 code block highlighting.
+
+```d2
+Duck: {
+	shape: class
+	beakColor: String
+	swim(): void
+	quack(): void
+}
+```

--- a/examples/sequence.d2
+++ b/examples/sequence.d2
@@ -1,0 +1,5 @@
+shape: sequence_diagram
+Alice -> John: Hello John, how are you?
+Alice -> John.ack: John, can you hear me?
+John.ack -> Alice: Hi Alice, I can hear you!
+John -> Alice: I feel great!

--- a/examples/shapes.d2
+++ b/examples/shapes.d2
@@ -1,0 +1,19 @@
+parse: {
+  shape: step
+}
+compile: {
+  shape: step
+}
+export: {
+  shape: step
+}
+
+parse -> compile -> export
+
+doc: {shape: page}
+cloud: {shape: cloud}
+
+doc -> cloud
+
+db: {shape: cylinder}
+pipeline: {shape: queue}

--- a/examples/state.d2
+++ b/examples/state.d2
@@ -1,0 +1,16 @@
+Start: "" {
+	shape: circle
+	width: 10
+}
+End: "" {
+	shape: circle
+	width: 10
+}
+
+Start -> Still
+Still -> End
+
+Still -> Moving
+Moving -> Still
+Moving -> Crash
+Crash -> End

--- a/examples/tables.d2
+++ b/examples/tables.d2
@@ -1,0 +1,30 @@
+car: {
+  shape: sql_table
+
+  id: int {constraint: primary_key}
+  last_updated: timestamp with time zone
+
+  make: string
+  model: string
+  year: int
+}
+
+factory: {
+  shape: sql_table
+
+  id: int {constraint: primary_key}
+
+  country: string
+}
+
+factory_car_support: {
+  shape: sql_table
+
+  id: int {constraint: primary_key}
+
+  factory: int {constraint: foreign_key}
+  car: int {constraint: foreign_key}
+}
+
+factory_car_support.factory -> factory.id
+factory_car_support.car -> car.id

--- a/examples/text.d2
+++ b/examples/text.d2
@@ -1,0 +1,11 @@
+description: |md
+  # Hope is a good breakfast, but it is a bad supper
+
+  - Look into my eyes and try to forget that you have a Macy's charge card!
+  - The **Tree of Learning** bears the noblest fruit, but noble fruit tastes bad.
+
+  "There is nothing new under the sun, but there are lots of old things
+  we don't know yet."
+    - *Ambrose Bierce*
+|
+description -> x

--- a/examples/trees.d2
+++ b/examples/trees.d2
@@ -1,0 +1,13 @@
+root
+
+root -> child A
+root -> child B
+root -> child C
+
+child A -> grand child AA
+child A -> grand child AB
+child A -> grand child AC
+child A -> grand child AD
+
+child B -> grand child BA
+grand child BA -> grand grand child BAA

--- a/examples/wiiu.d2
+++ b/examples/wiiu.d2
@@ -1,0 +1,47 @@
+ibm: IBM "Espresso" CPU {
+	core0: IBM PowerPC "Broadway" Core 0
+	core1: IBM PowerPC "Broadway" Core 1
+	core2: IBM PowerPC "Broadway" Core 2
+
+	rom: 16 KB ROM
+
+	core0 -- core2
+
+	rom -> core2
+}
+
+amd: AMD "Latte" GPU {
+	mem: Memory & I/O Bridge
+	dram: DRAM Controller
+	edram: 32 MB EDRAM "MEM1"
+	rom: 512 B SEEPROM
+	sata: SATA IF
+	exi: EXI
+
+	gx: GX {
+		3 MB 1T-SRAM
+	}
+
+	radeon: AMD Radeon R7xx "GX2"
+
+	mem -- gx
+	mem -- radeon
+
+	rom -- mem
+
+	mem -- sata
+	mem -- exi
+
+	dram -- sata
+	dram -- exi
+}
+
+ddr3: 2 GB DDR3 RAM "MEM2"
+
+amd.mem -- ddr3
+amd.dram -- ddr3
+amd.edram -- ddr3
+
+ibm.core1 -- amd.mem
+
+amd.exi -- RTC

--- a/languages/d2/highlights.scm
+++ b/languages/d2/highlights.scm
@@ -1,0 +1,61 @@
+;-------------------------------------------------------------------------------
+
+(container_key) @string.special
+(shape_key) @variable
+(attr_key) @property
+(reserved) @error
+(class_name) @constant
+
+[
+  (keyword_style)
+  (keyword_classes)
+  (keyword_class)
+] @keyword
+
+(keyword_underscore) @keyword.return
+
+; Literals
+;-------------------------------------------------------------------------------
+
+(string) @string
+(container_key (string (string_fragment) @string))
+(shape_key (string (string_fragment) @string))
+(escape_sequence) @string.escape
+(label) @text.title
+(attr_value) @string
+(integer) @number
+(float) @float
+(boolean) @boolean
+
+; Comments
+;-------------------------------------------------------------------------------
+
+[
+  (language)
+  (line_comment)
+  (block_comment)
+] @comment
+
+; Punctuation
+;-------------------------------------------------------------------------------
+
+(arrow) @operator
+
+[
+  (dot)
+  (colon)
+  ";"
+] @punctuation.delimiter
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+  "|"
+] @punctuation.bracket
+
+; Special
+;-------------------------------------------------------------------------------
+
+(ERROR) @error

--- a/languages/d2/indents.scm
+++ b/languages/d2/indents.scm
@@ -1,0 +1,19 @@
+[
+  (block)
+  (class_block)
+  (class_list)
+  (attr_value_list)
+  (ERROR . "{")
+  (ERROR . "[")
+] @indent.begin
+
+[
+  "}"
+  "]"
+] @indent.branch @indent.end
+
+[
+  (line_comment)
+  (block_comment)
+  (ERROR)
+] @indent.auto

--- a/languages/d2/injections.scm
+++ b/languages/d2/injections.scm
@@ -1,0 +1,48 @@
+; for tree-sitter
+
+(
+  (text_block . (raw_text) @injection.content)
+  (#set! injection.language "markdown")
+)
+
+(text_block
+  (language) @injection.language
+  (raw_text) @injection.content
+)
+
+(
+  (line_comment) @injection.content
+  (#set! @injection.language "comment")
+)
+(
+  (block_comment) @injection.content
+  (#set! @injection.language "comment")
+)
+
+;; -------------------------------------
+;; overwrite for nvim-treesitter
+; use markdown as default
+(text_block . (raw_text) @markdown)
+
+; add alias for markdown
+(text_block
+  (language) @_language
+  (raw_text) @markdown
+  (#eq? @_language "md")
+)
+
+; add alias for javascript
+(text_block
+  (language) @_language
+  (raw_text) @javascript
+  (#eq? @_language "js")
+)
+
+(text_block
+  (language) @language
+  (raw_text) @content
+)
+
+(line_comment) @comment
+(block_comment) @comment
+


### PR DESCRIPTION
Add initial syntax highlight support for both `.d2` files and `d2` code blocks in markdown files.