### PR TITLE
refactor!(d2): split injection queries from highlights to fix language conflict

### DIFF
--- a/languages/d2/highlights.scm
+++ b/languages/d2/highlights.scm
@@ -59,3 +59,22 @@
 ;-------------------------------------------------------------------------------
 
 (ERROR) @error
+
+;-------------------------------------------------------------------------------
+; Language-specific aliases for nvim-treesitter
+;-------------------------------------------------------------------------------
+
+(text_block . (raw_text) @markdown)
+
+(text_block
+  (language) @_language
+  (raw_text) @markdown
+  (#eq? @_language "md"))
+
+(text_block
+  (language) @_language
+  (raw_text) @javascript
+  (#eq? @_language "js"))
+
+(line_comment) @comment
+(block_comment) @comment

--- a/languages/d2/injections.scm
+++ b/languages/d2/injections.scm
@@ -1,48 +1,23 @@
-; for tree-sitter
-
+;; Language injection for markdown by default
 (
   (text_block . (raw_text) @injection.content)
   (#set! injection.language "markdown")
 )
 
-(text_block
-  (language) @injection.language
-  (raw_text) @injection.content
+;; Language-specific injection via explicit language node
+(
+  (text_block
+    (language) @injection.language
+    (raw_text) @injection.content)
 )
 
+;; Comment blocks as injectable content
 (
   (line_comment) @injection.content
   (#set! @injection.language "comment")
 )
+
 (
   (block_comment) @injection.content
   (#set! @injection.language "comment")
 )
-
-;; -------------------------------------
-;; overwrite for nvim-treesitter
-; use markdown as default
-(text_block . (raw_text) @markdown)
-
-; add alias for markdown
-(text_block
-  (language) @_language
-  (raw_text) @markdown
-  (#eq? @_language "md")
-)
-
-; add alias for javascript
-(text_block
-  (language) @_language
-  (raw_text) @javascript
-  (#eq? @_language "js")
-)
-
-(text_block
-  (language) @language
-  (raw_text) @content
-)
-
-(line_comment) @comment
-(block_comment) @comment
-


### PR DESCRIPTION
Move language aliases (e.g. @markdown, @javascript) from `injections.scm` to `highlights.scm` to avoid Tree-sitter error: "both language and injection.language captures are present".

- `injections.scm` now only contains valid language injection rules
- `highlights.scm` adds language-specific capture aliases for Neovim Treesitter
- Prevents injection loading failure in Tree-sitter and nvim-treesitter

BREAKING CHANGE: Downstream consumers relying on language aliases in `injections.scm` may need to update their queries or tooling.

Closes #6